### PR TITLE
Point hubot-thank-you to git repo to get latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "hubot-rules": "^0.1.0",
     "hubot-scripts": "^2.5.16",
     "hubot-shipit": "^0.1.1",
-    "hubot-thank-you": "0.0.3",
+    "hubot-thank-you": "git://github.com/hubot-scripts/hubot-thank-you",
     "hubot-youtube": "^0.1.2"
   },
   "engines": {


### PR DESCRIPTION
This will prevent @benfoxall having to say thank you twice every time.

It needs to point to repo as NPM hasn't been updated with the latest version
