### PR TITLE
Meetup api key

### DIFF
--- a/meetup-groups.json
+++ b/meetup-groups.json
@@ -1,0 +1,42 @@
+[
+  {
+    "name": "JS Oxford",
+    "id": "17778422",
+    "aliases": ["javascript", "js"]
+  },
+  {
+    "name": "UX Oxford",
+    "id": "12345482",
+    "aliases": ["ux"]
+  },
+  {
+    "name": "PHP Oxford",
+    "id": "18829161",
+    "aliases": ["php"]
+  },
+  {
+    "name": "Docker Oxford",
+    "id": "18789928",
+    "aliases": ["docker"]
+  },
+  {
+    "name": "OxRUG",
+    "id": "18617250",
+    "aliases": ["ruby", "rb", "rug"]
+  },
+  {
+    "name": "Oxford Python",
+    "id": "1722581",
+    "aliases": ["py"]
+  },
+  {
+    "name": "Doxford",
+    "id": "19558444",
+    "aliases": ["dox", "devop"]
+  },
+  {
+    "name": "Optimise Oxford",
+    "id": "18888248",
+    "aliases": ["optim"]
+  }
+]

--- a/scripts/meetup.js
+++ b/scripts/meetup.js
@@ -13,16 +13,18 @@
 var moment = require('moment-timezone');
 moment.locale('en-gb');
 
-module.exports = function(robot) {
-  var multipleEvents = "https://api.meetup.com/2/events?offset=0&format=json&limited_events=False&group_id=1722581%2C17778422%2C19558444%2C12345482%2C18829161%2C18789928%2C18617250%2C18888248&only=venue%2Cgroup%2Ctime%2Cevent_url%2Cname%2Cyes_rsvp_count%2Crsvp_limit&photo-host=secure&page=1&fields=&order=time&status=upcoming&desc=false&sig_id=153356232&sig=b9f7ecaae249501b3ad4ae9793b93ed0a8486b30";
-  var jsOxfordEvents = "https://api.meetup.com/2/events?offset=0&format=json&limited_events=False&group_id=17778422&only=venue%2Cgroup%2Ctime%2Cevent_url%2Cname%2Cyes_rsvp_count%2Crsvp_limit&photo-host=secure&page=1&fields=&order=time&status=upcoming&desc=false&sig_id=153356232&sig=6ba15c8304f28ef52aed15879097fca177d6f141";
-  var uxOxfordEvents = "https://api.meetup.com/2/events?offset=0&format=json&limited_events=False&group_id=12345482&only=venue%2Cgroup%2Ctime%2Cevent_url%2Cname%2Cyes_rsvp_count%2Crsvp_limit&photo-host=secure&page=1&fields=&order=time&status=upcoming&desc=false&sig_id=153356232&sig=a9b14566e686a419d7d2271b8d37f22e7c0f2abb";
-  var phpOxfordEvents = "https://api.meetup.com/2/events?offset=0&format=json&limited_events=False&group_id=18829161&only=venue%2Cgroup%2Ctime%2Cevent_url%2Cname%2Cyes_rsvp_count%2Crsvp_limit&photo-host=public&page=1&fields=&order=time&status=upcoming&desc=false&sig_id=153356232&sig=cca2fc38dc5e5489d26335d0f84193a735924d1c";
-  var dockerEvents = "https://api.meetup.com/2/events?offset=0&format=json&limited_events=False&group_id=18789928&only=venue%2Cgroup%2Ctime%2Cevent_url%2Cname%2Cyes_rsvp_count%2Crsvp_limit&photo-host=public&page=1&fields=&order=time&status=upcoming&desc=false&sig_id=153356232&sig=1d8ad02de7cc506d907e9b5b9ea1e181198dabae";
-  var rubyEvents = "https://api.meetup.com/2/events?offset=0&format=json&limited_events=False&group_id=18617250&only=venue%2Cgroup%2Ctime%2Cevent_url%2Cname%2Cyes_rsvp_count%2Crsvp_limit&photo-host=public&page=1&fields=&order=time&status=upcoming&desc=false&sig_id=153356232&sig=acfff477144fb6e4206d9a9870e2cc09f4bf77ab";
-  var pythonEvents = "https://api.meetup.com/2/events?offset=0&format=json&limited_events=False&group_id=1722581&only=venue%2Cgroup%2Ctime%2Cevent_url%2Cname%2Cyes_rsvp_count%2Crsvp_limit&photo-host=secure&page=1&fields=&order=time&status=upcoming&desc=false&sig_id=153356232&sig=fe019a9c33560a367dad9ae7a5737e967806011f";
-  var doxfordEvents = "https://api.meetup.com/2/events?offset=0&format=json&limited_events=False&group_id=19558444&only=venue%2Cgroup%2Ctime%2Cevent_url%2Cname%2Cyes_rsvp_count%2Crsvp_limit&photo-host=secure&page=1&fields=&order=time&status=upcoming&desc=false&sig_id=153356232&sig=c1b6e84e654381fac4ca07ae2773c5de2572cc19";
-  var optimiseEvents = "https://api.meetup.com/2/events?offset=0&format=json&limited_events=False&group_id=18888248&only=venue%2Cgroup%2Ctime%2Cevent_url%2Cname%2Cyes_rsvp_count%2Crsvp_limit&photo-host=secure&page=1&fields=&order=time&status=upcoming&desc=false&sig_id=153356232&sig=d9101daf5bd5385a8ec885e7aef4745ade5b21f1";
+module.exports = function (robot) {
+  var API_KEY = process.env.MEETUP_API_KEY;
+
+  var multipleEvents = "https://api.meetup.com/2/events?offset=0&format=json&limited_events=False&group_id=1722581%2C17778422%2C19558444%2C12345482%2C18829161%2C18789928%2C18617250%2C18888248&only=venue%2Cgroup%2Ctime%2Cevent_url%2Cname%2Cyes_rsvp_count%2Crsvp_limit&photo-host=secure&page=1&fields=&order=time&status=upcoming&desc=false&key=" + API_KEY;
+  var jsOxfordEvents = "https://api.meetup.com/2/events?offset=0&format=json&limited_events=False&group_id=17778422&only=venue%2Cgroup%2Ctime%2Cevent_url%2Cname%2Cyes_rsvp_count%2Crsvp_limit&photo-host=secure&page=1&fields=&order=time&status=upcoming&desc=false&key=" + API_KEY;
+  var uxOxfordEvents = "https://api.meetup.com/2/events?offset=0&format=json&limited_events=False&group_id=12345482&only=venue%2Cgroup%2Ctime%2Cevent_url%2Cname%2Cyes_rsvp_count%2Crsvp_limit&photo-host=secure&page=1&fields=&order=time&status=upcoming&desc=false&key=" + API_KEY;
+  var phpOxfordEvents = "https://api.meetup.com/2/events?offset=0&format=json&limited_events=False&group_id=18829161&only=venue%2Cgroup%2Ctime%2Cevent_url%2Cname%2Cyes_rsvp_count%2Crsvp_limit&photo-host=secure&page=1&fields=&order=time&status=upcoming&desc=false&key=" + API_KEY;
+  var dockerEvents = "https://api.meetup.com/2/events?offset=0&format=json&limited_events=False&group_id=18789928&only=venue%2Cgroup%2Ctime%2Cevent_url%2Cname%2Cyes_rsvp_count%2Crsvp_limit&photo-host=secure&page=1&fields=&order=time&status=upcoming&desc=false&key=" + API_KEY;
+  var rubyEvents = "https://api.meetup.com/2/events?offset=0&format=json&limited_events=False&group_id=18617250&only=venue%2Cgroup%2Ctime%2Cevent_url%2Cname%2Cyes_rsvp_count%2Crsvp_limit&photo-host=secure&page=1&fields=&order=time&status=upcoming&desc=false&key=" + API_KEY;
+  var pythonEvents = "https://api.meetup.com/2/events?offset=0&format=json&limited_events=False&group_id=1722581&only=venue%2Cgroup%2Ctime%2Cevent_url%2Cname%2Cyes_rsvp_count%2Crsvp_limit&photo-host=secure&page=1&fields=&order=time&status=upcoming&desc=false&key=" + API_KEY;
+  var doxfordEvents = "https://api.meetup.com/2/events?offset=0&format=json&limited_events=False&group_id=19558444&only=venue%2Cgroup%2Ctime%2Cevent_url%2Cname%2Cyes_rsvp_count%2Crsvp_limit&photo-host=secure&page=1&fields=&order=time&status=upcoming&desc=false&key=" + API_KEY;
+  var optimiseEvents = "https://api.meetup.com/2/events?offset=0&format=json&limited_events=False&group_id=18888248&only=venue%2Cgroup%2Ctime%2Cevent_url%2Cname%2Cyes_rsvp_count%2Crsvp_limit&photo-host=secure&page=1&fields=&order=time&status=upcoming&desc=false&key=" + API_KEY;
   var result;
 
   function phraseToUrl(phrase) {
@@ -47,7 +49,7 @@ module.exports = function(robot) {
     }
   }
 
-  robot.hear(/^(?:when|what)(?:s|'s| is) the next (.*)(?:meetup|event|talk|party|hack|shindig|gathering|meeting|happening)/i, function(msg) {
+  robot.hear(/^(?:when|what)(?:s|'s| is) the next (.*)(?:meetup|event|talk|party|hack|shindig|gathering|meeting|happening)/i, function (msg) {
     var room = msg.message.room.toLowerCase();
     var community = msg.match[1].toLowerCase();
     var meetupURL = phraseToUrl(community) || phraseToUrl(room) || multipleEvents;
@@ -56,7 +58,7 @@ module.exports = function(robot) {
     console.log('Community: ' + community);
     console.log('MeetupURL: ' + meetupURL);
 
-    robot.http(meetupURL).get()(function(err, res, body) {
+    robot.http(meetupURL).get()(function (err, res, body) {
       if (err) console.log(err);
       result = JSON.parse(body).results;
       if (result && result.length > 0) {

--- a/scripts/new-meetup.js
+++ b/scripts/new-meetup.js
@@ -12,8 +12,12 @@
 
 module.exports = function(robot) {
   var API_KEY = process.env.MEETUP_API_KEY;
+  var groups = require('../meetup-groups.json');
+  var allGroupIds = groups.map(function(group) {
+    return group.id;
+  }).join('%2C');
 
-  var meetupURL = "https://api.meetup.com/2/events?offset=0&format=json&limited_events=False&group_id=1722581%2C17778422%2C19558444%2C12345482%2C18829161%2C18789928%2C18617250%2C18888248&only=created%2Ctime%2Cevent_url%2Cname%2Cdescription%2Cyes_rsvp_count%2Crsvp_limit&photo-host=secure&page=20&fields=&order=time&status=upcoming&desc=false&key="+API_KEY;
+  var meetupURL = "https://api.meetup.com/2/events?offset=0&format=json&limited_events=False&group_id=" + allGroupIds + "&only=created%2Ctime%2Cevent_url%2Cname%2Cdescription%2Cyes_rsvp_count%2Crsvp_limit&photo-host=secure&page=20&fields=&order=time&status=upcoming&desc=false&key=" + API_KEY;
   var room = "#events";
   var result;
 

--- a/scripts/new-meetup.js
+++ b/scripts/new-meetup.js
@@ -11,7 +11,9 @@
 //   when is the next event ?  - returns the next upcoming meetup event
 
 module.exports = function(robot) {
-  var meetupURL = "https://api.meetup.com/2/events?offset=0&format=json&limited_events=False&group_id=1722581%2C17778422%2C19558444%2C12345482%2C18829161%2C18789928%2C18617250%2C18888248&only=created%2Ctime%2Cevent_url%2Cname%2Cdescription%2Cyes_rsvp_count%2Crsvp_limit&photo-host=secure&page=20&fields=&order=time&status=upcoming&desc=false&sig_id=153356232&sig=2caec369630b125aa3c13c9a259c7a26476a1141";
+  var API_KEY = process.env.MEETUP_API_KEY;
+
+  var meetupURL = "https://api.meetup.com/2/events?offset=0&format=json&limited_events=False&group_id=1722581%2C17778422%2C19558444%2C12345482%2C18829161%2C18789928%2C18617250%2C18888248&only=created%2Ctime%2Cevent_url%2Cname%2Cdescription%2Cyes_rsvp_count%2Crsvp_limit&photo-host=secure&page=20&fields=&order=time&status=upcoming&desc=false&key="+API_KEY;
   var room = "#events";
   var result;
 


### PR DESCRIPTION
So now we need to have MEETUP_API_KEY in the system environment variable.

I took away all the different URLs in favour of a single one which can be modified using values in `meetup-groups.json`. 

In that JSON file, we define the meetup group name, the ID and a number of 'aliases', or search terms that Dobot will pick up when the user asks `When's the next x meetup?`. For example, with OxRUG:

``` json
{
  "name": "OxRUG",
  "id": "18617250",
  "aliases": ["ruby", "rb", "rug"]
}
```

The user can ask `When's the next Ruby meetup?` or `rb` or `rug` or `oxrug`, since `rug` is a matching substring.

`name` is used when the API doesn't return any events. Now Dobot will return, for example `No upcoming JS Oxford events planned`

Group IDs can be found using the [Meetup API console](https://secure.meetup.com/meetup_api/console/?path=/2/groups).

I'm sure the code can be optimised somewhat, but that's a job for another evening.
