### PR TITLE
New Meetup announcements are more detailed

### DIFF
--- a/scripts/meetup.js
+++ b/scripts/meetup.js
@@ -35,7 +35,7 @@ module.exports = function (robot) {
     if (knownGroup) {
       groupName = groups.filter(function (group) {
         return group.id === meetupGroupId;
-      })[0].name;
+      })[0].name + ' ';
     }
 
     console.log('Room: ' + room);
@@ -48,7 +48,7 @@ module.exports = function (robot) {
       if (result && result.length > 0) {
         msg.send(responseForEvent(result[0], knownGroup));
       } else {
-        msg.send("No upcoming " + groupName + " events planned");
+        msg.send("No upcoming " + groupName + "events planned");
       }
     });
   }

--- a/scripts/new-meetup.js
+++ b/scripts/new-meetup.js
@@ -10,6 +10,9 @@
 // Commands:
 //   when is the next event ?  - returns the next upcoming meetup event
 
+var moment = require('moment-timezone');
+moment.locale('en-gb');
+
 module.exports = function(robot) {
   var API_KEY = process.env.MEETUP_API_KEY;
   var groups = require('../meetup-groups.json');
@@ -17,7 +20,7 @@ module.exports = function(robot) {
     return group.id;
   }).join('%2C');
 
-  var meetupURL = "https://api.meetup.com/2/events?offset=0&format=json&limited_events=False&group_id=" + allGroupIds + "&only=created%2Ctime%2Cevent_url%2Cname%2Cdescription%2Cyes_rsvp_count%2Crsvp_limit&photo-host=secure&page=20&fields=&order=time&status=upcoming&desc=false&key=" + API_KEY;
+  var meetupURL = "https://api.meetup.com/2/events?offset=0&format=json&limited_events=False&group_id=" + allGroupIds + "&only=created%2Ctime%2Cevent_url%2Cname%2Cdescription%2Cyes_rsvp_count%2Crsvp_limit%2Cgroup&photo-host=secure&page=20&fields=&order=time&status=upcoming&desc=false&key=" + API_KEY;
   var room = "#events";
   var result;
 
@@ -34,7 +37,7 @@ module.exports = function(robot) {
         result.forEach(function(meetup){
           var created = new Date(meetup.created);
           if(created > robot.brain.get("lastcheck")){
-            robot.messageRoom(room, meetup.event_url);
+            robot.messageRoom(room, generateAnnouncement(meetup));
           }
         });
       }
@@ -43,4 +46,12 @@ module.exports = function(robot) {
     });
   }, 1000 * 3600);
 
+}
+
+function generateAnnouncement(event) {
+  var eventTime = moment(event.time).tz('Europe/London').format('Do MMMM [at] h:mma');
+  var message = ':loudspeaker: New meetup!\n';
+  message += '"' + event.name + '" by ' + event.group.name + ', on the ' + eventTime + '\n';
+  message += event.event_url;
+  return message;
 }


### PR DESCRIPTION
Rather than just posting the URL, Dobot will now announce new meetups like this:
![image](https://cloud.githubusercontent.com/assets/5173183/14769267/636b79e6-0a4d-11e6-8086-e2d957222631.png)

Also fixed minor edge case where in the unlikely event nobody had any planned meetups, Dobot would respond `No upcoming  meetups planned` (with 2 spaces between 'upcoming' and 'meetups'). Now it's just the one.
^ turns out, even with preformatted code in between ` characters, it still removes the double space
