### PR TITLE
Add Oxford Hackspace to the ever-growing Meetup list

### DIFF
--- a/meetup-groups.json
+++ b/meetup-groups.json
@@ -41,5 +41,10 @@
   "20373353": {
     "name": "OX:Agile",
     "aliases": ["agile"]
+  },
+  "19781403": {
+    "name": "Oxford Hackspace",
+    "slack_channel": "#hacks",
+    "aliases": ["hack"]
   }
 }

--- a/meetup-groups.json
+++ b/meetup-groups.json
@@ -44,7 +44,6 @@
   },
   "19781403": {
     "name": "Oxford Hackspace",
-    "slack_channel": "#hacks",
     "aliases": ["hack"]
   }
 }


### PR DESCRIPTION
"When's the next hackspace event?"

> The next Oxford Hackspace meetup is "_Open Night / Social Night_" on _Thursday 29th September at 7:00pm_. It's at _Oxford Hackspace_.
> http://www.meetup.com/Oxford-Hackspace/events/234324121/
