### PR TITLE
Uses the Group Name from meetup-groups.json rather than using the Meetup API

### DIFF
--- a/meetup-groups.json
+++ b/meetup-groups.json
@@ -30,7 +30,7 @@
     "aliases": ["py"]
   },
   "19558444": {
-    "name": "Doxford",
+    "name": "DevOps Oxford",
     "slack_channel": "#devopsoxford",
     "aliases": ["dox", "devop"]
   },


### PR DESCRIPTION
Today, Dobot announced a new 'doxford' meetup, but really, the Meetup Group is called 'DevOps Oxford'.

The name 'doxford' comes from the Meetup API. The group name has been set to 'doxford' but in all of the event descriptions, it's referred to as 'DevOps Oxford'.

The same goes with Oxford Python. In Meetup, it's called 'Oxford Python Meetup Group', so when you ask Dobot about the next event, it'll respond "The next Oxford Python Meetup Group meetup is...", which is a bit of a mouthful.

So I thought rather than getting the Group Name from the Meetup API, why not just use the ones we've defined in `meetup-groups.json`? For the Python group, Dobot will now respond "The next Oxford Python meetup is..."

I've renamed 'Doxford' to 'DevOps Oxford' because that's what it says in the Meetup descriptions.
