### PR TITLE
Link new event to #meetup-buddies channel

### DIFF
--- a/scripts/new-meetup.js
+++ b/scripts/new-meetup.js
@@ -52,5 +52,6 @@ function generateAnnouncement(event, groups) {
   var eventTime = moment(event.time).tz('Europe/London').format('dddd Do MMMM [at] h:mma');
   return `${emoji('announce')} New ${groups[event.group.id].name} meetup!
 "${event.name}" is on ${eventTime}
-${event.event_url}`
+${event.event_url}
+Find a buddy to go with in #meetup-buddies!`
 }


### PR DESCRIPTION
Requested in slack: https://digitaloxford.slack.com/archives/general/p1484846622000331
>Maybe the channel could be called "meet up buddies" and it be plugged when events are publicised in slack :)?