### PR TITLE
add event city when describing an event

### DIFF
--- a/scripts/meetup.js
+++ b/scripts/meetup.js
@@ -95,7 +95,7 @@ function eventDetails(event) {
   var eventTime = moment(event.time).tz('Europe/London').format('dddd Do MMMM YYYY [at] h:mma');
   output = `"${event.name}" on ${eventTime}. `;
   if (event.venue && event.venue.name) {
-    output += `It ${isWas(event)} at ${event.venue.name}. `;
+    output += `It ${isWas(event)} at ${event.venue.name} (${event.venue.city}). `;
   }
   if (event.yes_rsvp_count && event.status === "upcoming") {
     if (event.rsvp_limit && event.rsvp_limit - event.yes_rsvp_count <= 10) {


### PR DESCRIPTION
Solution to this: 
![screen shot 2017-03-07 at 11 53 28](https://cloud.githubusercontent.com/assets/50949/23655391/bce10670-032c-11e7-8b99-ff52599ca00a.png)

With this change it should output (mostly) `(Oxford)`, but for the occasional cross-county event sharing, `(Bristol)`, `(London)`, etc.