### PR TITLE
Fixes #79: Look up outOfOxford value from meetup-groups.json instead of event

### DIFF
--- a/scripts/meetup.js
+++ b/scripts/meetup.js
@@ -42,7 +42,8 @@ module.exports = function (robot) {
       results = JSON.parse(body).results;
       if (results && results.length > 0) {
         groupName = groups[results[0].group.id].name;
-        msg.send(responseForEvent(results[0], groupName, knownGroup));
+        var outOfOxford = groups[results[0].group.id].outOfOxford;
+        msg.send(responseForEvent(results[0], groupName, knownGroup, outOfOxford));
       } else {
         groupName = knownGroup ? groups[meetupGroupId].name + ' ' : '';
         msg.send(`No upcoming ${groupName}events planned ${emoji('sad')}`);
@@ -71,7 +72,7 @@ module.exports = function (robot) {
 }
 
 
-function responseForEvent(event, groupName, knownGroup) {
+function responseForEvent(event, groupName, knownGroup, outOfOxford) {
   var eventUrl = event.event_url;
   var message;
   if (knownGroup) {
@@ -79,7 +80,7 @@ function responseForEvent(event, groupName, knownGroup) {
   } else {
     message = `The next meetup is by *${groupName}*, `;
   }
-  message += eventDetails(event);
+  message += eventDetails(event, outOfOxford);
   message += '\n' + eventUrl;
   return message;
 }
@@ -92,7 +93,7 @@ function meetupInfoResponse(event) {
   return `That event ${isWas(event)} ${eventDetails(event)}`;
 }
 
-function eventDetails(event) {
+function eventDetails(event, outOfOxford) {
   var eventTime = moment(event.time).tz('Europe/London').format('dddd Do MMMM YYYY [at] h:mma');
   output = `"${event.name}" on ${eventTime}. `;
   if (event.venue && event.venue.name) {
@@ -103,7 +104,7 @@ function eventDetails(event) {
       output += `There are ${event.rsvp_limit - event.yes_rsvp_count} places left. `;
     }
   }
-  if (event.outOfOxford) {
+  if (outOfOxford) {
     output += `This meetup takes place outside of Oxford. `;
   }
   return output;

--- a/scripts/new-meetup.js
+++ b/scripts/new-meetup.js
@@ -58,9 +58,9 @@ module.exports = function(robot) {
 
 }
 
-function outOfOxford(event) {
-  if (event.outOfOxford) {
-    return ' This meetup takes place outside of Oxford. '
+function outOfOxford(group) {
+  if (group.outOfOxford) {
+    return ' This meetup takes place outside of Oxford.'
   }
   return '';
 }
@@ -68,7 +68,7 @@ function outOfOxford(event) {
 function generateAnnouncement(event, groups) {
   var eventTime = moment(event.time).tz('Europe/London').format('dddd Do MMMM [at] h:mma');
   return `${emoji('announce')} New *${groups[event.group.id].name}* meetup!
-"${event.name}" is on ${eventTime} ${outOfOxford(event)}
+"${event.name}" is on ${eventTime}.${outOfOxford(groups[event.group.id])}
 ${event.event_url}
 Find a buddy to go with in <#C3T52T9NV|meetup-buddies>`
 }


### PR DESCRIPTION
The event from the Meetup API doesn't contain a property called `outOfOxford` - we were reading the value from the wrong object.

I've now read the value from `meetup-groups.json` and used it in `meetup.js` and `new-meetup.js`